### PR TITLE
Update Parrot_Os_Installer.sh

### DIFF
--- a/Parrot_Os_Installer.sh
+++ b/Parrot_Os_Installer.sh
@@ -42,11 +42,12 @@ echo "                                                                          
 
 function linux() {
 echo -e "$red [$green+$red]$off Installing Python ...";
-pip install python2.7
+pip install python
 echo -e "$red [$green+$red]$off Installing Modules ...";
 pip install -r requirements.txt
 pip install httplib2
 pip install mechanize
+pip install termcolor
 
 echo -e "$red [$green+$red]$off Checking directories..."
 if [ -d "/usr/share/ScreamingCobra" ]; then


### PR DESCRIPTION
You should change pip install python2.7 to pip intsall python,because python2.7 does not exist and it gives 404 error.
Also you should add pip install termcolor because when I done all the steps and run it,it gave me termcolor error